### PR TITLE
[feat] Implement rate limit

### DIFF
--- a/src/infra/OpenMeteoWeatherRepository.ts
+++ b/src/infra/OpenMeteoWeatherRepository.ts
@@ -74,7 +74,7 @@ export class OpenMeteoWeatherRepository implements WeatherRepository {
       ].join(','),
       start_date: date,
       end_date: date,
-      timezone: 'UTC',
+      timezone: 'JST',
     };
 
     const res = await axios.get('https://api.open-meteo.com/v1/forecast', { params });

--- a/src/interface/handlers/touringIndexHandler.ts
+++ b/src/interface/handlers/touringIndexHandler.ts
@@ -9,7 +9,7 @@ import { calculateTouringIndex } from "../../usecase/CalculateTouringIndex";
 export async function getTouringIndex(c: Context) {
   const lat = Number(c.req.query("lat"));
   const lon = Number(c.req.query("lon"));
-  const datetime = c.req.query("datetime") || new Date().toISOString();
+  const datetime = c.req.query("datetime") || new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString();
 
   if (isNaN(lat) || isNaN(lon)) {
     return c.json({ error: "lat and lon are required and must be numbers" }, 400);

--- a/src/interface/middleware/rateLimitMiddleware.ts
+++ b/src/interface/middleware/rateLimitMiddleware.ts
@@ -1,0 +1,145 @@
+import { Context } from "hono";
+
+interface RateLimitConfig {
+  windowMs: number; // Time window in milliseconds
+  maxRequests: number; // Maximum requests per window
+  keyPrefix?: string; // Prefix for KV keys
+}
+
+interface RateLimitInfo {
+  count: number;
+  resetTime: number;
+}
+
+/**
+ * Rate limiting middleware using KV storage
+ * Limits requests per IP address to prevent abuse
+ */
+export function createRateLimitMiddleware(config: RateLimitConfig) {
+  const {
+    windowMs = 60 * 1000, // Default: 1 minute
+    maxRequests = 100, // Default: 100 requests
+    keyPrefix = "rate_limit"
+  } = config;
+
+  return async (c: Context, next: () => Promise<void>) => {
+    const kv = c.env?.OPEN_METEO_CACHE;
+
+    if (!kv) {
+      // If KV is not available, skip rate limiting
+      console.warn("KV namespace not available, skipping rate limit");
+      await next();
+      return;
+    }
+
+    // Get client IP address
+    const clientIP = getClientIP(c);
+    const now = Date.now();
+    const windowStart = Math.floor(now / windowMs) * windowMs;
+    const rateLimitKey = `${keyPrefix}:${clientIP}:${windowStart}`;
+
+    try {
+      // Get current rate limit info
+      const existingData = await kv.get(rateLimitKey, "json") as RateLimitInfo | null;
+
+      let currentCount = 1;
+
+      if (existingData) {
+        currentCount = existingData.count + 1;
+      }
+
+      // Check if limit exceeded
+      if (currentCount > maxRequests) {
+        const resetTime = windowStart + windowMs;
+        const retryAfter = Math.ceil((resetTime - now) / 1000);
+
+        // Set rate limit headers
+        c.header("X-RateLimit-Limit", maxRequests.toString());
+        c.header("X-RateLimit-Remaining", "0");
+        c.header("X-RateLimit-Reset", Math.floor(resetTime / 1000).toString());
+        c.header("Retry-After", retryAfter.toString());
+
+        return c.json(
+          {
+            error: "Rate limit exceeded",
+            message: `Too many requests. Limit: ${maxRequests} requests per minute.`,
+            retryAfter: retryAfter
+          },
+          429
+        );
+      }
+
+      // Update rate limit info in KV
+      const rateLimitInfo: RateLimitInfo = {
+        count: currentCount,
+        resetTime: windowStart + windowMs
+      };
+
+      // Store with expiration slightly longer than window to handle clock skew
+      const expirationTtl = Math.ceil(windowMs / 1000) + 10;
+      await kv.put(rateLimitKey, JSON.stringify(rateLimitInfo), {
+        expirationTtl
+      });
+
+      // Set rate limit headers
+      const remaining = Math.max(0, maxRequests - currentCount);
+      const resetTime = windowStart + windowMs;
+
+      c.header("X-RateLimit-Limit", maxRequests.toString());
+      c.header("X-RateLimit-Remaining", remaining.toString());
+      c.header("X-RateLimit-Reset", Math.floor(resetTime / 1000).toString());
+
+    } catch (error) {
+      console.error("Rate limit middleware error:", error);
+      // On error, allow the request to proceed
+    }
+
+    await next();
+  };
+}
+
+/**
+ * Extract client IP address from request
+ * Handles various proxy headers
+ */
+function getClientIP(c: Context): string {
+  // Check common proxy headers
+  const forwardedFor = c.req.header("x-forwarded-for");
+  if (forwardedFor) {
+    // X-Forwarded-For can contain multiple IPs, take the first one
+    return forwardedFor.split(",")[0].trim();
+  }
+
+  const realIP = c.req.header("x-real-ip");
+  if (realIP) {
+    return realIP;
+  }
+
+  const cfConnectingIP = c.req.header("cf-connecting-ip");
+  if (cfConnectingIP) {
+    return cfConnectingIP;
+  }
+
+  // Fallback to a default IP if none found
+  return "unknown";
+}
+
+/**
+ * Pre-configured rate limiter for API endpoints
+ * 100 requests per minute per IP
+ */
+export const apiRateLimit = createRateLimitMiddleware({
+  windowMs: 60 * 1000, // 1 minute
+  maxRequests: 100, // 100 requests per minute
+  keyPrefix: "api_rate_limit"
+});
+
+/**
+ * Stricter rate limiter for auth endpoints
+ * 10 requests per minute per IP
+ */
+export const authRateLimit = createRateLimitMiddleware({
+  windowMs: 60 * 1000, // 1 minute
+  maxRequests: 10, // 10 requests per minute
+  keyPrefix: "auth_rate_limit"
+});

--- a/src/interface/router.ts
+++ b/src/interface/router.ts
@@ -2,8 +2,12 @@ import { Hono } from "hono";
 import { getTouringIndex, getTouringIndexHistory, postTouringIndexBatch } from "./handlers/touringIndexHandler";
 import { getWeather } from "./handlers/weatherHandler";
 import { healthCheck } from "./handlers/healthHandler";
+import { apiRateLimit } from "./middleware/rateLimitMiddleware";
 
 export const app = new Hono();
+
+// Apply rate limiting to all API routes
+app.use("/api/*", apiRateLimit);
 
 // Create API v1 router
 const apiV1Router = new Hono();
@@ -25,5 +29,5 @@ apiV1Router.route("/weather", weatherRouter);
 // Mount API v1 router
 app.route("/api/v1", apiV1Router);
 
-// Health check endpoint (outside of versioned API)
+// Health check endpoint (outside of versioned API) - no rate limit
 app.get("/health", healthCheck);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "jest"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This pull request introduces a rate-limiting middleware to improve API stability and updates timezone handling to align with the JST timezone. Additionally, it adjusts the default datetime logic in the `getTouringIndex` handler. Below are the key changes:

### Rate Limiting Implementation:
* Added a new `createRateLimitMiddleware` function in `src/interface/middleware/rateLimitMiddleware.ts` to enforce rate limits using KV storage. Two pre-configured rate limiters are included: `apiRateLimit` (100 requests/min) and `authRateLimit` (10 requests/min).
* Applied the `apiRateLimit` middleware to all API routes in `src/interface/router.ts` to prevent abuse.
* Clarified that the health check endpoint is excluded from rate limiting in `src/interface/router.ts`.

### Timezone and Datetime Adjustments:
* Updated the timezone parameter in `OpenMeteoWeatherRepository` from `UTC` to `JST` to reflect the new timezone requirement.
* Modified the default datetime logic in the `getTouringIndex` handler to use JST by adding a 9-hour offset to the current time.