### PR TITLE
[fix] Fix deployment timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,14 @@ jobs:
       - name: Run tests
         run: bun test
 
-      - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+      - name: Deploy to Cloudflare Workers (with retry)
+        uses: nick-invision/retry@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
This pull request updates the deployment workflow to improve reliability by introducing a retry mechanism for deploying to Cloudflare Workers.

**Workflow improvements:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L29-R39): Replaced the `cloudflare/wrangler-action` with `nick-invision/retry` to add retry logic for the deployment step. Configured the retry action with a timeout of 10 minutes, a maximum of 3 attempts, and a 30-second wait between retries. The deployment command now uses `bunx wrangler deploy`, and environment variables for Cloudflare credentials are explicitly passed.