### PR TITLE
[fix] Modify get open-meteo logic

### DIFF
--- a/src/constants/appConfig.ts
+++ b/src/constants/appConfig.ts
@@ -11,6 +11,9 @@ export const APP_CONFIG = {
   // Cache settings
   CACHE_EXPIRATION_HOURS: 3,
 
+  // Weather data defaults
+  DEFAULT_VISIBILITY_KM: 20, // Default visibility in kilometers for daily weather data
+
   // API URLs
   OPEN_METEO_API_BASE_URL: "https://api.open-meteo.com/v1",
   OPEN_METEO_FORECAST_ENDPOINT: "/forecast",

--- a/src/infra/OpenMeteoWeatherRepository.test.ts
+++ b/src/infra/OpenMeteoWeatherRepository.test.ts
@@ -98,38 +98,38 @@ describe("OpenMeteoWeatherRepository", () => {
       );
 
       // Should return 3 days of data
-      expect(result).toHaveLength(3);        // Check each day's data structure
-        result.forEach((weather, _index) => {
-          expect(weather).toHaveProperty("datetime");
-          expect(weather).toHaveProperty("condition");
-          expect(weather).toHaveProperty("temperature");
-          expect(weather).toHaveProperty("windSpeed");
-          expect(weather).toHaveProperty("humidity");
-          expect(weather).toHaveProperty("visibility");
-          expect(weather).toHaveProperty("precipitationProbability");
-          expect(weather).toHaveProperty("uvIndex");
+      expect(result).toHaveLength(3); // Check each day's data structure
+      result.forEach((weather, _index) => {
+        expect(weather).toHaveProperty("datetime");
+        expect(weather).toHaveProperty("condition");
+        expect(weather).toHaveProperty("temperature");
+        expect(weather).toHaveProperty("windSpeed");
+        expect(weather).toHaveProperty("humidity");
+        expect(weather).toHaveProperty("visibility");
+        expect(weather).toHaveProperty("precipitationProbability");
+        expect(weather).toHaveProperty("uvIndex");
 
-          // Verify datetime format for batch requests - should be valid ISO format
-          expect(isValidISODateTime(weather.datetime)).toBe(true);
+        // Verify datetime format for batch requests - should be valid ISO format
+        expect(isValidISODateTime(weather.datetime)).toBe(true);
 
-          // Verify visibility is set to default value for daily data
-          expect(weather.visibility).toBe(20);
+        // Verify visibility is set to default value for daily data
+        expect(weather.visibility).toBe(20);
 
-          // Verify reasonable value ranges
-          expect(weather.temperature).toBeGreaterThan(-50);
-          expect(weather.temperature).toBeLessThan(60);
-          expect(weather.windSpeed).toBeGreaterThanOrEqual(0);
-          expect(weather.humidity).toBeGreaterThanOrEqual(0);
-          expect(weather.humidity).toBeLessThanOrEqual(100);
-          expect(weather.precipitationProbability).toBeGreaterThanOrEqual(0);
-          expect(weather.precipitationProbability).toBeLessThanOrEqual(100);
-          expect(weather.uvIndex).toBeGreaterThanOrEqual(0);
-        });
+        // Verify reasonable value ranges
+        expect(weather.temperature).toBeGreaterThan(-50);
+        expect(weather.temperature).toBeLessThan(60);
+        expect(weather.windSpeed).toBeGreaterThanOrEqual(0);
+        expect(weather.humidity).toBeGreaterThanOrEqual(0);
+        expect(weather.humidity).toBeLessThanOrEqual(100);
+        expect(weather.precipitationProbability).toBeGreaterThanOrEqual(0);
+        expect(weather.precipitationProbability).toBeLessThanOrEqual(100);
+        expect(weather.uvIndex).toBeGreaterThanOrEqual(0);
+      });
 
-        // Verify correct date sequence using dynamic calculation
-        expect(result[0].datetime).toBe(getExpectedDailyDatetime("2025-06-01"));
-        expect(result[1].datetime).toBe(getExpectedDailyDatetime("2025-06-02"));
-        expect(result[2].datetime).toBe(getExpectedDailyDatetime("2025-06-03"));
+      // Verify correct date sequence using dynamic calculation
+      expect(result[0].datetime).toBe(getExpectedDailyDatetime("2025-06-01"));
+      expect(result[1].datetime).toBe(getExpectedDailyDatetime("2025-06-02"));
+      expect(result[2].datetime).toBe(getExpectedDailyDatetime("2025-06-03"));
     });
   });
 
@@ -181,7 +181,9 @@ describe("OpenMeteoWeatherRepository", () => {
       expect(singleResult.uvIndex).toBe(batchResult[0].uvIndex);
 
       // Verify batch result uses the expected datetime format
-      expect(batchResult[0].datetime).toBe(getExpectedDailyDatetime("2025-06-01"));
+      expect(batchResult[0].datetime).toBe(
+        getExpectedDailyDatetime("2025-06-01"),
+      );
     });
   });
 

--- a/src/infra/OpenMeteoWeatherRepository.ts
+++ b/src/infra/OpenMeteoWeatherRepository.ts
@@ -219,7 +219,7 @@ export class OpenMeteoWeatherRepository implements WeatherRepository {
           (daily.temperature_2m_max[idx] + daily.temperature_2m_min[idx]) / 2,
         windSpeed: daily.windspeed_10m_max[idx],
         humidity: daily.relative_humidity_2m_max[idx],
-        visibility: 20, // Default visibility for daily data
+        visibility: APP_CONFIG.DEFAULT_VISIBILITY_KM, // Default visibility for daily data
         precipitationProbability: daily.precipitation_probability_max[idx],
         uvIndex: daily.uv_index_max[idx],
       };
@@ -345,7 +345,7 @@ export class OpenMeteoWeatherRepository implements WeatherRepository {
             (daily.temperature_2m_max[i] + daily.temperature_2m_min[i]) / 2,
           windSpeed: daily.windspeed_10m_max[i],
           humidity: daily.relative_humidity_2m_max[i],
-          visibility: 20, // Default visibility for daily data
+          visibility: APP_CONFIG.DEFAULT_VISIBILITY_KM, // Default visibility for daily data
           precipitationProbability: daily.precipitation_probability_max[i],
           uvIndex: daily.uv_index_max[i],
         };


### PR DESCRIPTION
This pull request refactors the `OpenMeteoWeatherRepository` to switch from using hourly weather data to daily weather data and updates the corresponding tests to reflect these changes. The main changes include modifying the data fetching logic, updating the data structure and validation, and introducing comprehensive test cases for the repository.

### Refactoring to use daily weather data:
* [`src/infra/OpenMeteoWeatherRepository.ts`](diffhunk://#diff-809e3b5cff8eda89bbc9830c22592a002b683b4fd59b60d340f042bf38648ed8L139-R150): Changed the API request parameters to fetch daily weather data instead of hourly data, replacing fields like `temperature_2m` and `windspeed_10m` with their daily counterparts such as `temperature_2m_max` and `windspeed_10m_max`. Updated the logic to calculate averages and set default values for fields like visibility. [[1]](diffhunk://#diff-809e3b5cff8eda89bbc9830c22592a002b683b4fd59b60d340f042bf38648ed8L139-R150) [[2]](diffhunk://#diff-809e3b5cff8eda89bbc9830c22592a002b683b4fd59b60d340f042bf38648ed8L163) [[3]](diffhunk://#diff-809e3b5cff8eda89bbc9830c22592a002b683b4fd59b60d340f042bf38648ed8L177-R176) [[4]](diffhunk://#diff-809e3b5cff8eda89bbc9830c22592a002b683b4fd59b60d340f042bf38648ed8L187-R205) [[5]](diffhunk://#diff-809e3b5cff8eda89bbc9830c22592a002b683b4fd59b60d340f042bf38648ed8L223-R224)

### Enhanced testing for the repository:
* [`src/infra/OpenMeteoWeatherRepository.test.ts`](diffhunk://#diff-a048c63e137f77f010c6f45781348de234d8adfd093414f2a402195b59d9cbf6R1-R200): Replaced the single test case with a suite of integration tests. These tests validate the structure, types, and value ranges of the returned weather data for both single and batch requests, check consistency between single and batch data, and ensure proper mapping of weather codes.