### PR TITLE
fix: Make getWeatherBatch call API individually for each date

### DIFF
--- a/src/infra/WeatherApiWeatherRepository.ts
+++ b/src/infra/WeatherApiWeatherRepository.ts
@@ -338,20 +338,12 @@ export class WeatherApiWeatherRepository implements WeatherRepository {
       return [];
     }
 
-    // Fetch once and reuse values to satisfy interface and tests
-    // Normalize base fetch time to use T03:00:00Z consistently
-    const base = await this.getWeather(lat, lon, `${days[0]}T03:00:00Z`);
-
-    const results: Weather[] = days.map((dateStr) => ({
-      datetime: `${dateStr}T03:00:00Z`, // 12:00 JST = 03:00 UTC
-      condition: base.condition,
-      temperature: base.temperature,
-      windSpeed: base.windSpeed,
-      humidity: base.humidity,
-      visibility: APP_CONFIG.DEFAULT_VISIBILITY_KM,
-      precipitationProbability: base.precipitationProbability,
-      uvIndex: base.uvIndex,
-    }));
+    // Fetch weather data individually for each date
+    const results: Weather[] = [];
+    for (const dateStr of days) {
+      const weather = await this.getWeather(lat, lon, `${dateStr}T03:00:00Z`); // 12:00 JST = 03:00 UTC
+      results.push(weather);
+    }
 
     return results;
   }


### PR DESCRIPTION
## Summary
- Fixed getWeatherBatch method to call weather API individually for each date instead of reusing data from the first date
- This resolves the issue where all dates were returning identical weather data

## Problem
The `getWeatherBatch` method was fetching weather data only once for the first date and reusing the same values for all other dates, causing identical weather data to be returned regardless of the date requested.

## Solution
Changed the implementation to make individual API calls for each date in the batch, ensuring accurate date-specific weather data.

## Test plan
- [x] Verify that different dates now return different weather data
- [x] Test that the API integration works correctly with individual calls
- [ ] Run existing tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)